### PR TITLE
Feat: add addresses in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Spark ALM Controller
+# Sky Star ALM Controller
+
+**This repository was cloned from spark [ALM Controller](https://github.com/sparkdotfi/spark-alm-controller)**
 
 ![Foundry CI](https://github.com/marsfoundation/spark-alm-controller/actions/workflows/ci.yml/badge.svg)
 [![Foundry][foundry-badge]][foundry]

--- a/deploy/ControllerDeploy.sol
+++ b/deploy/ControllerDeploy.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.8.0;
 
+import { Ethereum } from "spark-address-registry/Ethereum.sol";
+
 import { ALMProxy }          from "../src/ALMProxy.sol";
 import { ForeignController } from "../src/ForeignController.sol";
 import { MainnetController } from "../src/MainnetController.sol";
@@ -54,6 +56,17 @@ library ForeignControllerDeploy {
 }
 
 library MainnetControllerDeploy {
+    
+    function _addresses() internal pure returns (MainnetController.Addresses memory addresses) {
+        return MainnetController.Addresses({
+                USDS                  : Ethereum.USDS,
+                USDE                  : Ethereum.USDE,
+                SUSDE                 : Ethereum.SUSDE,
+                USTB                  : Ethereum.USTB,
+                ETHENA_MINTER         : Ethereum.ETHENA_MINTER,
+                SUPERSTATE_REDEMPTION : Ethereum.SUPERSTATE_REDEMPTION
+        });
+    }
 
     function deployController(
         address admin,
@@ -73,7 +86,8 @@ library MainnetControllerDeploy {
             vault_      : vault,
             psm_        : psm,
             daiUsds_    : daiUsds,
-            cctp_       : cctp
+            cctp_       : cctp,
+            addresses   : _addresses()
         }));
     }
 
@@ -96,7 +110,8 @@ library MainnetControllerDeploy {
             vault_      : vault,
             psm_        : psm,
             daiUsds_    : daiUsds,
-            cctp_       : cctp
+            cctp_       : cctp,
+            addresses   : _addresses()
         }));
     }
 

--- a/src/MainnetController.sol
+++ b/src/MainnetController.sol
@@ -12,8 +12,6 @@ import { IMetaMorpho, Id, MarketAllocation } from "metamorpho/interfaces/IMetaMo
 
 import { AccessControl } from "openzeppelin-contracts/contracts/access/AccessControl.sol";
 
-import { Ethereum } from "spark-address-registry/Ethereum.sol";
-
 import { IALMProxy }   from "./interfaces/IALMProxy.sol";
 import { ICCTPLike }   from "./interfaces/CCTPInterfaces.sol";
 import { IRateLimits } from "./interfaces/IRateLimits.sol";
@@ -76,6 +74,18 @@ interface IVaultLike {
 contract MainnetController is AccessControl {
 
     using OptionsBuilder for bytes;
+
+    /**********************************************************************************************/
+    /*** Structs                                                                                ***/
+    /**********************************************************************************************/
+    struct Addresses {
+        address USDS;
+        address USDE;
+        address SUSDE;
+        address USTB;
+        address ETHENA_MINTER;
+        address SUPERSTATE_REDEMPTION;
+    }
 
     /**********************************************************************************************/
     /*** Events                                                                                 ***/
@@ -153,7 +163,8 @@ contract MainnetController is AccessControl {
         address vault_,
         address psm_,
         address daiUsds_,
-        address cctp_
+        address cctp_,
+        Addresses memory addresses
     ) {
         _grantRole(DEFAULT_ADMIN_ROLE, admin_);
 
@@ -165,15 +176,15 @@ contract MainnetController is AccessControl {
         daiUsds    = IDaiUsdsLike(daiUsds_);
         cctp       = ICCTPLike(cctp_);
 
-        ethenaMinter         = IEthenaMinterLike(Ethereum.ETHENA_MINTER);
-        superstateRedemption = ISSRedemptionLike(Ethereum.SUPERSTATE_REDEMPTION);
+        ethenaMinter         = IEthenaMinterLike(addresses.ETHENA_MINTER);
+        superstateRedemption = ISSRedemptionLike(addresses.SUPERSTATE_REDEMPTION);
 
-        susde = ISUSDELike(Ethereum.SUSDE);
-        ustb  = IUSTBLike(Ethereum.USTB);
+        susde = ISUSDELike(addresses.SUSDE);
+        ustb  = IUSTBLike(addresses.USTB);
         dai   = IERC20(daiUsds.dai());
         usdc  = IERC20(psm.gem());
-        usds  = IERC20(Ethereum.USDS);
-        usde  = IERC20(Ethereum.USDE);
+        usds  = IERC20(addresses.USDS);
+        usde  = IERC20(addresses.USDE);
 
         psmTo18ConversionFactor = psm.to18ConversionFactor();
     }

--- a/test/mainnet-fork/Approve.t.sol
+++ b/test/mainnet-fork/Approve.t.sol
@@ -26,8 +26,9 @@ contract MainnetControllerHarness is MainnetController {
         address vault_,
         address psm_,
         address daiUsds_,
-        address cctp_
-    ) MainnetController(admin_, proxy_, rateLimits_, vault_, psm_, daiUsds_, cctp_) {}
+        address cctp_,
+        MainnetController.Addresses memory addresses_
+    ) MainnetController(admin_, proxy_, rateLimits_, vault_, psm_, daiUsds_, cctp_, addresses_) {}
 
     function approve(address token, address spender, uint256 amount) external {
         _approve(token, spender, amount);
@@ -102,7 +103,15 @@ contract MainnetControllerApproveSuccessTests is ApproveTestBase {
             address(mainnetController.vault()),
             address(mainnetController.psm()),
             address(mainnetController.daiUsds()),
-            address(mainnetController.cctp())
+            address(mainnetController.cctp()),
+            MainnetController.Addresses({
+                USDS                  : address(mainnetController.usds()),
+                USDE                  : address(mainnetController.usde()),
+                SUSDE                 : address(mainnetController.susde()),
+                USTB                  : address(mainnetController.ustb()),
+                ETHENA_MINTER         : address(mainnetController.ethenaMinter()),
+                SUPERSTATE_REDEMPTION : address(mainnetController.superstateRedemption())
+            })
         );
 
         vm.etch(address(mainnetController), address(harnessCode).code);

--- a/test/unit/controllers/Admin.t.sol
+++ b/test/unit/controllers/Admin.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.21;
 
+import { Ethereum } from "spark-address-registry/Ethereum.sol";
+
 import { ForeignController } from "../../../src/ForeignController.sol";
 import { MainnetController } from "../../../src/MainnetController.sol";
 
@@ -35,7 +37,15 @@ contract MainnetControllerAdminTestBase is UnitTestBase {
             address(vault),
             address(psm),
             address(daiUsds),
-            makeAddr("cctp")
+            makeAddr("cctp"),
+            MainnetController.Addresses({
+                USDS                  : Ethereum.USDS,
+                USDE                  : Ethereum.USDE,
+                SUSDE                 : Ethereum.SUSDE,
+                USTB                  : Ethereum.USTB,
+                ETHENA_MINTER         : Ethereum.ETHENA_MINTER,
+                SUPERSTATE_REDEMPTION : Ethereum.SUPERSTATE_REDEMPTION
+            })
         );
     }
 

--- a/test/unit/controllers/Constructor.t.sol
+++ b/test/unit/controllers/Constructor.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.21;
 
+import { Ethereum } from "spark-address-registry/Ethereum.sol";
+
 import { ForeignController } from "../../../src/ForeignController.sol";
 import { MainnetController } from "../../../src/MainnetController.sol";
 
@@ -25,7 +27,15 @@ contract MainnetControllerConstructorTests is UnitTestBase {
             address(vault),
             address(psm),
             address(daiUsds),
-            makeAddr("cctp")
+            makeAddr("cctp"),
+            MainnetController.Addresses({
+                USDS                  : Ethereum.USDS,
+                USDE                  : Ethereum.USDE,
+                SUSDE                 : Ethereum.SUSDE,
+                USTB                  : Ethereum.USTB,
+                ETHENA_MINTER         : Ethereum.ETHENA_MINTER,
+                SUPERSTATE_REDEMPTION : Ethereum.SUPERSTATE_REDEMPTION
+            })
         );
 
         assertEq(mainnetController.hasRole(DEFAULT_ADMIN_ROLE, admin), true);

--- a/test/unit/controllers/Freezer.t.sol
+++ b/test/unit/controllers/Freezer.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.21;
 
+import { Ethereum } from "spark-address-registry/Ethereum.sol";
+
 import { MainnetController } from "../../../src/MainnetController.sol";
 import { ForeignController } from "../../../src/ForeignController.sol";
 
@@ -32,7 +34,15 @@ contract MainnetControllerRemoveRelayerTests is UnitTestBase {
             address(vault),
             address(psm),
             address(daiUsds),
-            makeAddr("cctp")
+            makeAddr("cctp"),
+            MainnetController.Addresses({
+                USDS                  : Ethereum.USDS,
+                USDE                  : Ethereum.USDE,
+                SUSDE                 : Ethereum.SUSDE,
+                USTB                  : Ethereum.USTB,
+                ETHENA_MINTER         : Ethereum.ETHENA_MINTER,
+                SUPERSTATE_REDEMPTION : Ethereum.SUPERSTATE_REDEMPTION
+            })
         );
 
         vm.startPrank(admin);


### PR DESCRIPTION
This PR removes [spark-address-registry](https://github.com/sparkdotfi/spark-address-registry/blob/172ee4d0801de863744983eb6707946e7ca2920d/src/Ethereum.sol) dependency from `MainnetController` and replace it with constructor arguments.