### PR TITLE
feat: Add e2e tests and transferAsset to ForeignController (SC-1118 + SC-1113)

### DIFF
--- a/test/base-fork/SparkVault.t.sol
+++ b/test/base-fork/SparkVault.t.sol
@@ -12,64 +12,60 @@ contract ForeignControllerTakeFromSparkVaultTestBase is ForkTestBase {
 
     struct TestState {
         uint256 rateLimit;
-        uint256 assetAlm;
-        uint256 assetVault;
+        uint256 usdcAlm;
+        uint256 usdcVault;
         uint256 vaultTotalAssets;
         uint256 vaultTotalSupply;
     }
 
+    address user = makeAddr("user");
+
     bytes32 LIMIT_SPARK_VAULT_TAKE = keccak256("LIMIT_SPARK_VAULT_TAKE");
-
-    // TODO: Use a real on-chain contract.
-    // NOTE: The mock asset has 18 decimals.
-    MockERC20  asset;
-    SparkVault sparkVault;
-
-    address admin  = makeAddr("admin");
-    address setter = makeAddr("setter");
-    address user   = makeAddr("user");
 
     bytes32 key;
 
+    SparkVault sparkVault;
+
     function setUp() public override {
         super.setUp();
-
-        asset = new MockERC20();
 
         sparkVault = SparkVault(
             address(new ERC1967Proxy(
                 address(new SparkVault()),
                 abi.encodeCall(
                     SparkVault.initialize,
-                    (address(asset), "Spark Savings USDC V2", "spUSDC", admin)
+                    (address(usdcBase), "Spark Savings USDC V2", "spUSDC", Base.SPARK_EXECUTOR)
                 )
             ))
         );
-
-        vm.startPrank(admin);
-        sparkVault.grantRole(sparkVault.TAKER_ROLE(), address(almProxy));
-        vm.stopPrank();
 
         key = RateLimitHelpers.makeAssetKey(
             LIMIT_SPARK_VAULT_TAKE,
             address(sparkVault)
         );
 
-        vm.prank(Base.SPARK_EXECUTOR);
-        rateLimits.setRateLimitData(key, 1_000_000e18, uint256(1_000_000e18) / 1 days);
+        vm.startPrank(Base.SPARK_EXECUTOR);
+        sparkVault.grantRole(sparkVault.TAKER_ROLE(), address(almProxy));
+        rateLimits.setRateLimitData(key, 1_000_000e6, uint256(1_000_000e6) / 1 days);
+        vm.stopPrank();
+    }
+
+    function _getBlock() internal pure override returns (uint256) {
+        return 34717833;  // August 26, 2025
     }
 
     function _assertTestState(TestState memory state, uint256 tolerance) internal view {
-        assertApproxEqAbs(rateLimits.getCurrentRateLimit(key),  state.rateLimit,        tolerance, "rateLimit");
-        assertApproxEqAbs(asset.balanceOf(address(almProxy)),   state.assetAlm,         tolerance, "assetAlm");
-        assertApproxEqAbs(asset.balanceOf(address(sparkVault)), state.assetVault,       tolerance, "assetVault");
-        assertApproxEqAbs(sparkVault.totalAssets(),             state.vaultTotalAssets, tolerance, "vaultTotalAssets");
-        assertApproxEqAbs(sparkVault.totalSupply(),             state.vaultTotalSupply, tolerance, "vaultTotalSupply");
+        assertApproxEqAbs(rateLimits.getCurrentRateLimit(key),     state.rateLimit,        tolerance, "rateLimit");
+        assertApproxEqAbs(usdcBase.balanceOf(address(almProxy)),   state.usdcAlm,          tolerance, "usdcAlm");
+        assertApproxEqAbs(usdcBase.balanceOf(address(sparkVault)), state.usdcVault,        tolerance, "usdcVault");
+        assertApproxEqAbs(sparkVault.totalAssets(),                state.vaultTotalAssets, tolerance, "vaultTotalAssets");
+        assertApproxEqAbs(sparkVault.totalSupply(),                state.vaultTotalSupply, tolerance, "vaultTotalSupply");
     }
 
     function _assertTestState(TestState memory state) internal view {
         _assertTestState(state, 0);
     }
+
 }
 
 contract ForeignControllerTakeFromSparkVaultFailureTests is ForeignControllerTakeFromSparkVaultTestBase {
@@ -93,21 +89,21 @@ contract ForeignControllerTakeFromSparkVaultFailureTests is ForeignControllerTak
     }
 
     function test_takeFromSparkVault_rateLimitBoundary() external {
-        deal(address(asset), address(user), 10_000_000e18);
+        deal(address(usdcBase), address(user), 10_000_000e6);
         vm.startPrank(user);
-        asset.approve(address(sparkVault), 10_000_000e18);
-        sparkVault.deposit(10_000_000e18, address(user));
+        usdcBase.approve(address(sparkVault), 10_000_000e6);
+        sparkVault.deposit(10_000_000e6, address(user));
         vm.stopPrank();
 
         vm.prank(Base.SPARK_EXECUTOR);
-        rateLimits.setRateLimitData(key, 10_000_000e18, uint256(10_000_000e18) / 1 days);
+        rateLimits.setRateLimitData(key, 10_000_000e6, uint256(10_000_000e6) / 1 days);
 
         vm.prank(relayer);
         vm.expectRevert("RateLimits/rate-limit-exceeded");
-        foreignController.takeFromSparkVault(address(sparkVault), 10_000_000e18 + 1);
+        foreignController.takeFromSparkVault(address(sparkVault), 10_000_000e6 + 1);
 
         vm.prank(relayer);
-        foreignController.takeFromSparkVault(address(sparkVault), 10_000_000e18);
+        foreignController.takeFromSparkVault(address(sparkVault), 10_000_000e6);
     }
 
 }
@@ -115,35 +111,35 @@ contract ForeignControllerTakeFromSparkVaultFailureTests is ForeignControllerTak
 contract ForeignControllerTakeFromSparkVaultTests is ForeignControllerTakeFromSparkVaultTestBase {
 
     function test_takeFromSparkVault_rateLimited() external {
-        deal(address(asset), address(user), 10_000_000e18);
+        deal(address(usdcBase), address(user), 10_000_000e6);
         vm.startPrank(user);
-        asset.approve(address(sparkVault), 10_000_000e18);
-        sparkVault.deposit(10_000_000e18, address(user));
+        usdcBase.approve(address(sparkVault), 10_000_000e6);
+        sparkVault.deposit(10_000_000e6, address(user));
         vm.stopPrank();
 
         TestState memory testState = TestState({
-            rateLimit:        1_000_000e18,
-            assetAlm:         0,
-            assetVault:       10_000_000e18,
-            vaultTotalAssets: 10_000_000e18,
-            vaultTotalSupply: 10_000_000e18
+            rateLimit:        1_000_000e6,
+            usdcAlm:          0,
+            usdcVault:        10_000_000e6,
+            vaultTotalAssets: 10_000_000e6,
+            vaultTotalSupply: 10_000_000e6
         });
 
         _assertTestState(testState);
 
         vm.prank(relayer);
-        foreignController.takeFromSparkVault(address(sparkVault), 1_000_000e18);
+        foreignController.takeFromSparkVault(address(sparkVault), 1_000_000e6);
 
-        testState.rateLimit  -= 1_000_000e18;  // Rate limit goes down
-        testState.assetAlm   += 1_000_000e18;  // The almProxy receives the taken amount
-        testState.assetVault -= 1_000_000e18;  // The vault's asset balance decreases
+        testState.rateLimit -= 1_000_000e6;  // Rate limit goes down
+        testState.usdcAlm   += 1_000_000e6;  // The almProxy receives the taken amount
+        testState.usdcVault -= 1_000_000e6;  // The vault's usdc balance decreases
 
         _assertTestState(testState);
 
         skip(1 hours);
 
         // 1/24th of the rate limit per hour
-        uint256 rateLimitIncreaseInOneHour = uint256(1_000_000e18) / (1 days) * (1 hours);
+        uint256 rateLimitIncreaseInOneHour = uint256(1_000_000e6) / (1 days) * (1 hours);
         assertEq(rateLimitIncreaseInOneHour, 41666.666666666666666400e18);
 
         testState.rateLimit += rateLimitIncreaseInOneHour;
@@ -153,9 +149,9 @@ contract ForeignControllerTakeFromSparkVaultTests is ForeignControllerTakeFromSp
         vm.prank(relayer);
         foreignController.takeFromSparkVault(address(sparkVault), rateLimitIncreaseInOneHour);
 
-        testState.rateLimit  -= rateLimitIncreaseInOneHour;  // Rate limit goes down
-        testState.assetAlm   += rateLimitIncreaseInOneHour;  // The almProxy receives the taken amount
-        testState.assetVault -= rateLimitIncreaseInOneHour;  // The vault's asset balance decreases
+        testState.rateLimit -= rateLimitIncreaseInOneHour;  // Rate limit goes down
+        testState.usdcAlm   += rateLimitIncreaseInOneHour;  // The almProxy receives the taken amount
+        testState.usdcVault -= rateLimitIncreaseInOneHour;  // The vault's usdc balance decreases
 
         _assertTestState(testState);
 
@@ -171,16 +167,16 @@ contract ForeignControllerTakeFromSparkVaultTests is ForeignControllerTakeFromSp
         depositAmount = _bound(depositAmount, 1e18, 10_000_000_000e18);
         takeAmount    = _bound(depositAmount, 1e18, depositAmount);
 
-        deal(address(asset), address(user), depositAmount);
+        deal(address(usdcBase), address(user), depositAmount);
         vm.startPrank(user);
-        asset.approve(address(sparkVault), depositAmount);
+        usdcBase.approve(address(sparkVault), depositAmount);
         sparkVault.deposit(depositAmount, address(user));
         vm.stopPrank();
 
         TestState memory testState = TestState({
             rateLimit:        10_000_000_000e18,
-            assetAlm:         0,
-            assetVault:       depositAmount,
+            usdcAlm:          0,
+            usdcVault:        depositAmount,
             vaultTotalAssets: depositAmount,
             vaultTotalSupply: depositAmount
         });
@@ -190,12 +186,226 @@ contract ForeignControllerTakeFromSparkVaultTests is ForeignControllerTakeFromSp
         vm.prank(relayer);
         foreignController.takeFromSparkVault(address(sparkVault), takeAmount);
 
-        testState.rateLimit  -= takeAmount;  // Rate limit goes down
-        testState.assetAlm   += takeAmount;  // The almProxy receives the taken amount
-        testState.assetVault -= takeAmount;  // The vault's asset balance decreases
+        testState.rateLimit -= takeAmount;  // Rate limit goes down
+        testState.usdcAlm   += takeAmount;  // The almProxy receives the taken amount
+        testState.usdcVault -= takeAmount;  // The vault's usdc balance decreases
 
         _assertTestState(testState);
     }
 
 }
 
+contract ForeignControllerTakeFromSparkVaultE2ETests is ForkTestBase {
+
+    struct E2ETestState {
+        uint256 takeRateLimit;
+        uint256 transferRateLimit;
+        uint256 usdcAlm;
+        uint256 usdcVault;
+        uint256 vaultAssetsOut;
+        uint256 vaultTotalAssets;
+        uint256 vaultTotalSupply;
+    }
+
+    address morphoUsdcVault = Base.MORPHO_VAULT_SUSDC;
+
+    bytes32 LIMIT_4626_DEPOSIT     = keccak256("LIMIT_4626_DEPOSIT");
+    bytes32 LIMIT_4626_WITHDRAW    = keccak256("LIMIT_4626_WITHDRAW");
+    bytes32 LIMIT_ASSET_TRANSFER   = keccak256("LIMIT_ASSET_TRANSFER");
+    bytes32 LIMIT_SPARK_VAULT_TAKE = keccak256("LIMIT_SPARK_VAULT_TAKE");
+    bytes32 LIMIT_USDS_TO_USDC     = keccak256("LIMIT_USDS_TO_USDC");
+
+    address user = makeAddr("user");
+
+    bytes32 takeKey;
+    bytes32 transferKey;
+
+    SparkVault sparkVault;
+
+    function setUp() public override {
+        super.setUp();
+
+        // Step 1: Deploy the spark vault
+
+        sparkVault = SparkVault(
+            address(new ERC1967Proxy(
+                address(new SparkVault()),
+                abi.encodeCall(
+                    SparkVault.initialize,
+                    (address(usdcBase), "Spark Savings USDC V2", "spUSDC", Base.SPARK_EXECUTOR)
+                )
+            ))
+        );
+
+        // Step 2 (spell): Grant roles to the almProxy and setter, set VSR bounds
+
+        vm.startPrank(Base.SPARK_EXECUTOR);
+
+        sparkVault.grantRole(sparkVault.TAKER_ROLE(),  address(almProxy));
+        sparkVault.grantRole(sparkVault.SETTER_ROLE(), relayer);
+
+        sparkVault.setVsrBounds(1e27, 1.000000003022265980097387650e27);  // 0% to 10% APY
+
+        // Step 3 (spell): Set the rate limits
+
+        takeKey = RateLimitHelpers.makeAssetKey(
+            LIMIT_SPARK_VAULT_TAKE,
+            address(sparkVault)
+        );
+
+        transferKey = RateLimitHelpers.makeAssetDestinationKey(
+            LIMIT_ASSET_TRANSFER,
+            address(usdcBase),
+            address(sparkVault)
+        );
+
+        bytes32 morphoKey = RateLimitHelpers.makeAssetKey(
+            LIMIT_4626_DEPOSIT,
+            address(morphoUsdcVault)
+        );
+
+        bytes32 morphoWithdrawKey = RateLimitHelpers.makeAssetKey(
+            LIMIT_4626_WITHDRAW,
+            address(morphoUsdcVault)
+        );
+
+        rateLimits.setRateLimitData(takeKey,            10_000_000e6, uint256(10_000_000e6) / 1 days);
+        rateLimits.setRateLimitData(transferKey,        10_000_000e6, uint256(10_000_000e6) / 1 days);
+        rateLimits.setRateLimitData(morphoKey,          10_000_000e6, uint256(10_000_000e6) / 1 days);
+        rateLimits.setRateLimitData(LIMIT_USDS_TO_USDC, 10_000_000e6, uint256(10_000_000e6) / 1 days);
+
+        rateLimits.setUnlimitedRateLimitData(morphoWithdrawKey);
+
+        vm.stopPrank();
+    }
+
+    function _getBlock() internal pure override returns (uint256) {
+        return 34717833;  // August 26, 2025
+    }
+
+    function _assertE2EState(E2ETestState memory state, uint256 tolerance) internal view {
+        assertApproxEqAbs(rateLimits.getCurrentRateLimit(takeKey),     state.takeRateLimit,     tolerance, "takeRateLimit");
+        assertApproxEqAbs(rateLimits.getCurrentRateLimit(transferKey), state.transferRateLimit, tolerance, "transferRateLimit");
+
+        assertApproxEqAbs(usdcBase.balanceOf(address(almProxy)),   state.usdcAlm,          tolerance, "usdcAlm");
+        assertApproxEqAbs(usdcBase.balanceOf(address(sparkVault)), state.usdcVault,        tolerance, "usdcVault");
+        assertApproxEqAbs(sparkVault.totalAssets(),                state.vaultTotalAssets, tolerance, "vaultTotalAssets");
+        assertApproxEqAbs(sparkVault.totalSupply(),                state.vaultTotalSupply, tolerance, "vaultTotalSupply");
+        assertApproxEqAbs(sparkVault.assetsOutstanding(),          state.vaultAssetsOut,   tolerance, "vaultAssetsOut");
+    }
+
+    function _assertE2EState(E2ETestState memory state) internal view {
+        _assertE2EState(state, 0);
+    }
+
+    function test_e2e_takeFromSparkVault() external {
+        // Step 1: Set the initial state
+
+        E2ETestState memory testState = E2ETestState({
+            takeRateLimit:     10_000_000e6,
+            transferRateLimit: 10_000_000e6,
+            usdcAlm:           0,
+            usdcVault:         0,
+            vaultAssetsOut:    0,
+            vaultTotalAssets:  0,
+            vaultTotalSupply:  0
+        });
+
+        _assertE2EState(testState);
+
+        skip(1 days);
+
+        // Step 2: Deposit usdc into the spark vault
+
+        deal(address(usdcBase), address(user), 10_000_000e6);
+        vm.startPrank(user);
+        usdcBase.approve(address(sparkVault), 10_000_000e6);
+        sparkVault.deposit(10_000_000e6, address(user));
+        vm.stopPrank();
+
+        testState.usdcVault        = 10_000_000e6;
+        testState.vaultTotalAssets = 10_000_000e6;
+        testState.vaultTotalSupply = 10_000_000e6;
+
+        _assertE2EState(testState);
+
+        skip(1 days);
+
+        // Step 3: Take usdc from the spark vault
+
+        vm.prank(relayer);
+        foreignController.takeFromSparkVault(address(sparkVault), 9_000_000e6);
+
+        testState.takeRateLimit  = 1_000_000e6;
+        testState.usdcAlm        = 9_000_000e6;
+        testState.usdcVault      = 1_000_000e6;
+        testState.vaultAssetsOut = 9_000_000e6;
+
+        _assertE2EState(testState);
+
+        skip(10 days);  // Get full rate limit for Morpho deposit
+
+        // Step 4: Deposit into Morpho and set the VSR to 4% APY
+
+        vm.startPrank(relayer);
+        uint256 shares = foreignController.depositERC4626(morphoUsdcVault, 9_000_000e6);
+        sparkVault.setVsr(1.000000001243680656318820312e27);  // 4% APY
+        vm.stopPrank();
+
+        testState.takeRateLimit = 10_000_000e6;
+        testState.usdcAlm       = 0;
+
+        _assertE2EState(testState);  // No state changes
+
+        skip(365 days);
+
+        // Step 5: Show state change after a year (easiest for APY assertions)
+
+        // 4% APY on 10m USDC = 500k USDC
+        // NOTE: The APY is on the full value of the vault, NOT the take amount.
+        testState.vaultTotalAssets = 10_400_000e6 - 1;  // Rounding
+        testState.vaultAssetsOut   = 9_400_000e6 - 1;   // Rounding
+
+        _assertE2EState(testState);
+
+        // Step 6: Redeem assets from Morpho, swap DAI to USDC and transfer outstanding assets to the vault
+
+        vm.startPrank(relayer);
+        uint256 assets = foreignController.redeemERC4626(morphoUsdcVault, shares);
+        foreignController.transferAsset(address(usdcBase), address(sparkVault), 9_400_000e6);
+        vm.stopPrank();
+
+        assertEq(assets, 9_414_173.844477081922732043e18);  // ~414k in yield
+
+        uint256 almProfit = assets - 9_400_000e18;  // 9.4m owed to the vault
+
+        // testState.transferRateLimit = 600_000e6;  // 10m - 9.4m
+        // testState.daiAlm            = almProfit;
+        // testState.usdcAlm           = 0;
+        // testState.usdcVault         = 10_400_000e6;
+        // testState.vaultAssetsOut    = 0;
+
+        // _assertE2EState(testState);
+
+        // // Step 7: User withdraws all assets
+
+        // vm.startPrank(user);
+        // sparkVault.withdraw(sparkVault.assetsOf(user), user, user);
+        // vm.stopPrank();
+
+        // // Vault is empty and ALM system has some profit
+        // _assertE2EState(E2ETestState({
+        //     takeRateLimit:     10_000_000e6,
+        //     transferRateLimit: 600_000e6,
+        //     usdcAlm:           0,
+        //     usdcVault:         1,  // Rounding against user
+        //     vaultAssetsOut:    0,
+        //     vaultTotalAssets:  0,
+        //     vaultTotalSupply:  0
+        // }));
+
+        // // User has all funds, and has earned a 4% APY on their deposit
+        // assertEq(usdcBase.balanceOf(user), 10_400_000e6 - 1);  // Rounding against user
+    }
+
+}

--- a/test/base-fork/SparkVault.t.sol
+++ b/test/base-fork/SparkVault.t.sol
@@ -140,7 +140,7 @@ contract ForeignControllerTakeFromSparkVaultTests is ForeignControllerTakeFromSp
 
         // 1/24th of the rate limit per hour
         uint256 rateLimitIncreaseInOneHour = uint256(1_000_000e6) / (1 days) * (1 hours);
-        assertEq(rateLimitIncreaseInOneHour, 41666.666666666666666400e18);
+        assertEq(rateLimitIncreaseInOneHour, 41666.666666e6);
 
         testState.rateLimit += rateLimitIncreaseInOneHour;
 

--- a/test/base-fork/SparkVault.t.sol
+++ b/test/base-fork/SparkVault.t.sol
@@ -140,7 +140,7 @@ contract ForeignControllerTakeFromSparkVaultTests is ForeignControllerTakeFromSp
 
         // 1/24th of the rate limit per hour
         uint256 rateLimitIncreaseInOneHour = uint256(1_000_000e6) / (1 days) * (1 hours);
-        assertEq(rateLimitIncreaseInOneHour, 41666.666666e6);
+        assertEq(rateLimitIncreaseInOneHour, 41666.666400e6);
 
         testState.rateLimit += rateLimitIncreaseInOneHour;
 

--- a/test/base-fork/SparkVault.t.sol
+++ b/test/base-fork/SparkVault.t.sol
@@ -375,37 +375,36 @@ contract ForeignControllerTakeFromSparkVaultE2ETests is ForkTestBase {
         foreignController.transferAsset(address(usdcBase), address(sparkVault), 9_400_000e6);
         vm.stopPrank();
 
-        assertEq(assets, 9_414_173.844477081922732043e18);  // ~414k in yield
+        assertEq(assets, 9_424_512.250438e6);  // ~414k in yield
 
-        uint256 almProfit = assets - 9_400_000e18;  // 9.4m owed to the vault
+        uint256 almProfit = assets - 9_400_000e6;  // 9.4m owed to the vault
 
-        // testState.transferRateLimit = 600_000e6;  // 10m - 9.4m
-        // testState.daiAlm            = almProfit;
-        // testState.usdcAlm           = 0;
-        // testState.usdcVault         = 10_400_000e6;
-        // testState.vaultAssetsOut    = 0;
+        testState.transferRateLimit = 600_000e6;  // 10m - 9.4m
+        testState.usdcAlm           = almProfit;
+        testState.usdcVault         = 10_400_000e6;
+        testState.vaultAssetsOut    = 0;
 
-        // _assertE2EState(testState);
+        _assertE2EState(testState);
 
-        // // Step 7: User withdraws all assets
+        // Step 7: User withdraws all assets
 
-        // vm.startPrank(user);
-        // sparkVault.withdraw(sparkVault.assetsOf(user), user, user);
-        // vm.stopPrank();
+        vm.startPrank(user);
+        sparkVault.withdraw(sparkVault.assetsOf(user), user, user);
+        vm.stopPrank();
 
-        // // Vault is empty and ALM system has some profit
-        // _assertE2EState(E2ETestState({
-        //     takeRateLimit:     10_000_000e6,
-        //     transferRateLimit: 600_000e6,
-        //     usdcAlm:           0,
-        //     usdcVault:         1,  // Rounding against user
-        //     vaultAssetsOut:    0,
-        //     vaultTotalAssets:  0,
-        //     vaultTotalSupply:  0
-        // }));
+        // Vault is empty and ALM system has some profit
+        _assertE2EState(E2ETestState({
+            takeRateLimit:     10_000_000e6,
+            transferRateLimit: 600_000e6,
+            usdcAlm:           almProfit,
+            usdcVault:         1,  // Rounding against user
+            vaultAssetsOut:    0,
+            vaultTotalAssets:  0,
+            vaultTotalSupply:  0
+        }));
 
-        // // User has all funds, and has earned a 4% APY on their deposit
-        // assertEq(usdcBase.balanceOf(user), 10_400_000e6 - 1);  // Rounding against user
+        // User has all funds, and has earned a 4% APY on their deposit
+        assertEq(usdcBase.balanceOf(user), 10_400_000e6 - 1);  // Rounding against user
     }
 
 }

--- a/test/base-fork/TransferAsset.t.sol
+++ b/test/base-fork/TransferAsset.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.8.0;
+
+import { IERC4626 } from "forge-std/interfaces/IERC4626.sol";
+
+import { IMetaMorpho, Id }       from "metamorpho/interfaces/IMetaMorpho.sol";
+import { MarketParamsLib }       from "morpho-blue/src/libraries/MarketParamsLib.sol";
+import { IMorpho, MarketParams } from "morpho-blue/src/interfaces/IMorpho.sol";
+
+import { RateLimitHelpers } from "../../src/RateLimitHelpers.sol";
+
+import "./ForkTestBase.t.sol";
+
+contract TransferAssetBaseTest is ForkTestBase {
+
+    address destination = makeAddr("destination");
+
+    function setUp() public override {
+        super.setUp();
+
+        vm.startPrank(Base.SPARK_EXECUTOR);
+
+        rateLimits.setRateLimitData(
+            RateLimitHelpers.makeAssetDestinationKey(
+                foreignController.LIMIT_ASSET_TRANSFER(),
+                address(usdcBase),
+                destination
+            ),
+            1_000_000e6,
+            uint256(1_000_000e6) / 1 days
+        );
+
+        vm.stopPrank();
+    }
+
+}
+
+contract ForeignControllerTransferAssetFailureTests is TransferAssetBaseTest {
+
+    function test_transferAsset_notRelayer() external {
+        vm.expectRevert(abi.encodeWithSignature(
+            "AccessControlUnauthorizedAccount(address,bytes32)",
+            address(this),
+            RELAYER
+        ));
+        foreignController.transferAsset(address(usdcBase), destination, 1_000_000e6);
+    }
+
+    function test_transferAsset_zeroMaxAmount() external {
+        vm.prank(relayer);
+        vm.expectRevert("RateLimits/zero-maxAmount");
+        foreignController.transferAsset(makeAddr("fake-token"), destination, 1e18);
+    }
+
+    function test_transferAsset_rateLimitedBoundary() external {
+        deal(address(usdcBase), address(almProxy), 1_000_000e6 + 1);
+
+        vm.expectRevert("RateLimits/rate-limit-exceeded");
+        vm.startPrank(relayer);
+        foreignController.transferAsset(address(usdcBase), destination, 1_000_000e6 + 1);
+
+        foreignController.transferAsset(address(usdcBase), destination, 1_000_000e6);
+    }
+
+}
+
+contract ForeignControllerTransferAssetSuccessTests is TransferAssetBaseTest {
+
+    function test_transferAsset() external {
+        deal(address(usdcBase), address(almProxy), 1_000_000e6);
+
+        assertEq(usdcBase.balanceOf(address(destination)), 0);
+        assertEq(usdcBase.balanceOf(address(almProxy)),    1_000_000e6);
+
+        vm.prank(relayer);
+        foreignController.transferAsset(address(usdcBase), destination, 1_000_000e6);
+
+        assertEq(usdcBase.balanceOf(address(destination)), 1_000_000e6);
+        assertEq(usdcBase.balanceOf(address(almProxy)),    0);
+    }
+
+}

--- a/test/mainnet-fork/SparkVault.t.sol
+++ b/test/mainnet-fork/SparkVault.t.sol
@@ -203,8 +203,6 @@ contract MainnetControllerTakeFromSparkVaultE2ETests is ForkTestBase {
         uint256 vaultTotalSupply;
     }
 
-    address constant ATOKEN_USDS = 0xC02aB1A5eaA8d1B114EF786D9bde108cD4364359;
-
     address morphoDaiVault = Ethereum.MORPHO_VAULT_DAI_1;
 
     bytes32 LIMIT_4626_DEPOSIT     = keccak256("LIMIT_4626_DEPOSIT");
@@ -350,7 +348,7 @@ contract MainnetControllerTakeFromSparkVaultE2ETests is ForkTestBase {
         vm.startPrank(relayer);
         mainnetController.swapUSDCToUSDS(9_000_000e6);
         mainnetController.swapUSDSToDAI(9_000_000e18);
-        uint256 shares = mainnetController.depositERC4626(Ethereum.MORPHO_VAULT_DAI_1, 9_000_000e18);
+        uint256 shares = mainnetController.depositERC4626(address(morphoDaiVault), 9_000_000e18);
         sparkVault.setVsr(1.000000001243680656318820312e27);  // 4% APY
         vm.stopPrank();
 
@@ -373,7 +371,7 @@ contract MainnetControllerTakeFromSparkVaultE2ETests is ForkTestBase {
         // Step 6: Redeem assets from Morpho, swap DAI to USDC and transfer outstanding assets to the vault
 
         vm.startPrank(relayer);
-        uint256 assets = mainnetController.redeemERC4626(Ethereum.MORPHO_VAULT_DAI_1, shares);
+        uint256 assets = mainnetController.redeemERC4626(address(morphoDaiVault), shares);
         mainnetController.swapDAIToUSDS(9_400_000e18);
         mainnetController.swapUSDSToUSDC(9_400_000e6);
         mainnetController.transferAsset(address(usdc), address(sparkVault), 9_400_000e6);

--- a/test/mainnet-fork/SparkVault.t.sol
+++ b/test/mainnet-fork/SparkVault.t.sol
@@ -135,7 +135,7 @@ contract MainnetControllerTakeFromSparkVaultTests is MainnetControllerTakeFromSp
 
         // 1/24th of the rate limit per hour
         uint256 rateLimitIncreaseInOneHour = uint256(1_000_000e6) / (1 days) * (1 hours);
-        assertEq(rateLimitIncreaseInOneHour, 41666.666666e6);
+        assertEq(rateLimitIncreaseInOneHour, 41666.666400e6);
 
         testState.rateLimit += rateLimitIncreaseInOneHour;
 

--- a/test/mainnet-fork/SparkVault.t.sol
+++ b/test/mainnet-fork/SparkVault.t.sol
@@ -10,7 +10,7 @@ import "./ForkTestBase.t.sol";
 
 contract MainnetControllerTakeFromSparkVaultTestBase is ForkTestBase {
 
-    struct UnitTestState {
+    struct TestState {
         uint256 rateLimit;
         uint256 usdcAlm;
         uint256 usdcVault;
@@ -18,26 +18,13 @@ contract MainnetControllerTakeFromSparkVaultTestBase is ForkTestBase {
         uint256 vaultTotalSupply;
     }
 
-    struct E2ETestState {
-        uint256 takeRateLimit;
-        uint256 transferRateLimit;
-        uint256 usdcAlm;
-        uint256 usdcVault;
-        uint256 vaultTotalAssets;
-        uint256 vaultTotalSupply;
-    }
+    address user = makeAddr("user");
 
-    bytes32 LIMIT_ASSET_TRANSFER   = keccak256("LIMIT_ASSET_TRANSFER");
     bytes32 LIMIT_SPARK_VAULT_TAKE = keccak256("LIMIT_SPARK_VAULT_TAKE");
 
+    bytes32 key;
+
     SparkVault sparkVault;
-
-    address admin  = makeAddr("admin");
-    address setter = makeAddr("setter");
-    address user   = makeAddr("user");
-
-    bytes32 takeKey;
-    bytes32 transferKey;
 
     function setUp() public override {
         super.setUp();
@@ -47,59 +34,33 @@ contract MainnetControllerTakeFromSparkVaultTestBase is ForkTestBase {
                 address(new SparkVault()),
                 abi.encodeCall(
                     SparkVault.initialize,
-                    (address(usdc), "Spark Savings USDC V2", "spUSDC", admin)
+                    (address(usdc), "Spark Savings USDC V2", "spUSDC", Ethereum.SPARK_PROXY)
                 )
             ))
         );
 
-        vm.startPrank(admin);
-        sparkVault.grantRole(sparkVault.TAKER_ROLE(),  address(almProxy));
-        sparkVault.grantRole(sparkVault.SETTER_ROLE(), address(setter));
-        vm.stopPrank();
-
-        takeKey = RateLimitHelpers.makeAssetKey(
+        key = RateLimitHelpers.makeAssetKey(
             LIMIT_SPARK_VAULT_TAKE,
             address(sparkVault)
         );
 
-        transferKey = RateLimitHelpers.makeAssetDestinationKey(
-            LIMIT_ASSET_TRANSFER,
-            address(usdc),
-            address(sparkVault)
-        );
-
         vm.startPrank(Ethereum.SPARK_PROXY);
-        rateLimits.setRateLimitData(takeKey,     1_000_000e18, uint256(1_000_000e18) / 1 days);
-        rateLimits.setRateLimitData(transferKey, 1_000_000e18, uint256(1_000_000e18) / 1 days);
+        sparkVault.grantRole(sparkVault.TAKER_ROLE(), address(almProxy));
+        rateLimits.setRateLimitData(key, 1_000_000e6, uint256(1_000_000e6) / 1 days);
         vm.stopPrank();
     }
 
-    function _assertUnitTestState(UnitTestState memory state, uint256 tolerance) internal view {
-        assertApproxEqAbs(rateLimits.getCurrentRateLimit(takeKey), state.rateLimit,        tolerance, "rateLimit");
-        assertApproxEqAbs(usdc.balanceOf(address(almProxy)),       state.usdcAlm,          tolerance, "usdcAlm");
-        assertApproxEqAbs(usdc.balanceOf(address(sparkVault)),     state.usdcVault,        tolerance, "usdcVault");
-        assertApproxEqAbs(sparkVault.totalAssets(),                state.vaultTotalAssets, tolerance, "vaultTotalAssets");
-        assertApproxEqAbs(sparkVault.totalSupply(),                state.vaultTotalSupply, tolerance, "vaultTotalSupply");
-    }
-
-    function _assertE2EState(E2ETestState memory state, uint256 tolerance) internal view {
-        assertApproxEqAbs(rateLimits.getCurrentRateLimit(takeKey),      state.takeRateLimit,     tolerance, "takeRateLimit");
-        assertApproxEqAbs(rateLimits.getCurrentRateLimit(transferKey), state.transferRateLimit, tolerance, "transferRateLimit");
-
+    function _assertTestState(TestState memory state, uint256 tolerance) internal view {
+        assertApproxEqAbs(rateLimits.getCurrentRateLimit(key), state.rateLimit,        tolerance, "rateLimit");
         assertApproxEqAbs(usdc.balanceOf(address(almProxy)),   state.usdcAlm,          tolerance, "usdcAlm");
         assertApproxEqAbs(usdc.balanceOf(address(sparkVault)), state.usdcVault,        tolerance, "usdcVault");
         assertApproxEqAbs(sparkVault.totalAssets(),            state.vaultTotalAssets, tolerance, "vaultTotalAssets");
         assertApproxEqAbs(sparkVault.totalSupply(),            state.vaultTotalSupply, tolerance, "vaultTotalSupply");
     }
 
-    function _assertUnitTestState(UnitTestState memory state) internal view {
-        _assertUnitTestState(state, 0);
+    function _assertTestState(TestState memory state) internal view {
+        _assertTestState(state, 0);
     }
-
-    function _assertE2EState(E2ETestState memory state) internal view {
-        _assertE2EState(state, 0);
-    }
-
 }
 
 contract MainnetControllerTakeFromSparkVaultFailureTests is MainnetControllerTakeFromSparkVaultTestBase {
@@ -115,7 +76,7 @@ contract MainnetControllerTakeFromSparkVaultFailureTests is MainnetControllerTak
 
     function test_takeFromSparkVault_zeroMaxAmount() external {
         vm.prank(Ethereum.SPARK_PROXY);
-        rateLimits.setRateLimitData(takeKey, 0, 0);
+        rateLimits.setRateLimitData(key, 0, 0);
 
         vm.prank(relayer);
         vm.expectRevert("RateLimits/zero-maxAmount");
@@ -123,21 +84,21 @@ contract MainnetControllerTakeFromSparkVaultFailureTests is MainnetControllerTak
     }
 
     function test_takeFromSparkVault_rateLimitBoundary() external {
-        deal(address(usdc), address(user), 10_000_000e18);
+        deal(address(usdc), address(user), 10_000_000e6);
         vm.startPrank(user);
-        usdc.approve(address(sparkVault), 10_000_000e18);
-        sparkVault.deposit(10_000_000e18, address(user));
+        usdc.approve(address(sparkVault), 10_000_000e6);
+        sparkVault.deposit(10_000_000e6, address(user));
         vm.stopPrank();
 
         vm.prank(Ethereum.SPARK_PROXY);
-        rateLimits.setRateLimitData(takeKey, 10_000_000e18, uint256(10_000_000e18) / 1 days);
+        rateLimits.setRateLimitData(key, 10_000_000e6, uint256(10_000_000e6) / 1 days);
 
         vm.prank(relayer);
         vm.expectRevert("RateLimits/rate-limit-exceeded");
-        mainnetController.takeFromSparkVault(address(sparkVault), 10_000_000e18 + 1);
+        mainnetController.takeFromSparkVault(address(sparkVault), 10_000_000e6 + 1);
 
         vm.prank(relayer);
-        mainnetController.takeFromSparkVault(address(sparkVault), 10_000_000e18);
+        mainnetController.takeFromSparkVault(address(sparkVault), 10_000_000e6);
     }
 
 }
@@ -145,40 +106,40 @@ contract MainnetControllerTakeFromSparkVaultFailureTests is MainnetControllerTak
 contract MainnetControllerTakeFromSparkVaultTests is MainnetControllerTakeFromSparkVaultTestBase {
 
     function test_takeFromSparkVault_rateLimited() external {
-        deal(address(usdc), address(user), 10_000_000e18);
+        deal(address(usdc), address(user), 10_000_000e6);
         vm.startPrank(user);
-        usdc.approve(address(sparkVault), 10_000_000e18);
-        sparkVault.deposit(10_000_000e18, address(user));
+        usdc.approve(address(sparkVault), 10_000_000e6);
+        sparkVault.deposit(10_000_000e6, address(user));
         vm.stopPrank();
 
-        UnitTestState memory testState = UnitTestState({
-            rateLimit:        1_000_000e18,
+        TestState memory testState = TestState({
+            rateLimit:        1_000_000e6,
             usdcAlm:          0,
-            usdcVault:        10_000_000e18,
-            vaultTotalAssets: 10_000_000e18,
-            vaultTotalSupply: 10_000_000e18
+            usdcVault:        10_000_000e6,
+            vaultTotalAssets: 10_000_000e6,
+            vaultTotalSupply: 10_000_000e6
         });
 
-        _assertUnitTestState(testState);
+        _assertTestState(testState);
 
         vm.prank(relayer);
-        mainnetController.takeFromSparkVault(address(sparkVault), 1_000_000e18);
+        mainnetController.takeFromSparkVault(address(sparkVault), 1_000_000e6);
 
-        testState.rateLimit -= 1_000_000e18;  // Rate limit goes down
-        testState.usdcAlm   += 1_000_000e18;  // The almProxy receives the taken amount
-        testState.usdcVault -= 1_000_000e18;  // The vault's usdc balance decreases
+        testState.rateLimit -= 1_000_000e6;  // Rate limit goes down
+        testState.usdcAlm   += 1_000_000e6;  // The almProxy receives the taken amount
+        testState.usdcVault -= 1_000_000e6;  // The vault's usdc balance decreases
 
-        _assertUnitTestState(testState);
+        _assertTestState(testState);
 
         skip(1 hours);
 
         // 1/24th of the rate limit per hour
-        uint256 rateLimitIncreaseInOneHour = uint256(1_000_000e18) / (1 days) * (1 hours);
+        uint256 rateLimitIncreaseInOneHour = uint256(1_000_000e6) / (1 days) * (1 hours);
         assertEq(rateLimitIncreaseInOneHour, 41666.666666666666666400e18);
 
         testState.rateLimit += rateLimitIncreaseInOneHour;
 
-        _assertUnitTestState(testState);
+        _assertTestState(testState);
 
         vm.prank(relayer);
         mainnetController.takeFromSparkVault(address(sparkVault), rateLimitIncreaseInOneHour);
@@ -187,7 +148,7 @@ contract MainnetControllerTakeFromSparkVaultTests is MainnetControllerTakeFromSp
         testState.usdcAlm   += rateLimitIncreaseInOneHour;  // The almProxy receives the taken amount
         testState.usdcVault -= rateLimitIncreaseInOneHour;  // The vault's usdc balance decreases
 
-        _assertUnitTestState(testState);
+        _assertTestState(testState);
 
         vm.prank(relayer);
         vm.expectRevert("RateLimits/rate-limit-exceeded");
@@ -195,10 +156,8 @@ contract MainnetControllerTakeFromSparkVaultTests is MainnetControllerTakeFromSp
     }
 
     function testFuzz_takeFromSparkVault(uint256 depositAmount, uint256 takeAmount) external {
-        vm.startPrank(Ethereum.SPARK_PROXY);
-        rateLimits.setRateLimitData(takeKey,     10_000_000_000e18, uint256(10_000_000_000e18) / 1 days);
-        rateLimits.setRateLimitData(transferKey, 10_000_000_000e18, uint256(10_000_000_000e18) / 1 days);
-        vm.stopPrank();
+        vm.prank(Ethereum.SPARK_PROXY);
+        rateLimits.setRateLimitData(key, 10_000_000_000e18, uint256(10_000_000_000e18) / 1 days);
 
         depositAmount = _bound(depositAmount, 1e18, 10_000_000_000e18);
         takeAmount    = _bound(depositAmount, 1e18, depositAmount);
@@ -209,7 +168,7 @@ contract MainnetControllerTakeFromSparkVaultTests is MainnetControllerTakeFromSp
         sparkVault.deposit(depositAmount, address(user));
         vm.stopPrank();
 
-        UnitTestState memory testState = UnitTestState({
+        TestState memory testState = TestState({
             rateLimit:        10_000_000_000e18,
             usdcAlm:          0,
             usdcVault:        depositAmount,
@@ -217,7 +176,7 @@ contract MainnetControllerTakeFromSparkVaultTests is MainnetControllerTakeFromSp
             vaultTotalSupply: depositAmount
         });
 
-        _assertUnitTestState(testState);
+        _assertTestState(testState);
 
         vm.prank(relayer);
         mainnetController.takeFromSparkVault(address(sparkVault), takeAmount);
@@ -226,19 +185,232 @@ contract MainnetControllerTakeFromSparkVaultTests is MainnetControllerTakeFromSp
         testState.usdcAlm   += takeAmount;  // The almProxy receives the taken amount
         testState.usdcVault -= takeAmount;  // The vault's usdc balance decreases
 
-        _assertUnitTestState(testState);
+        _assertTestState(testState);
     }
 
 }
 
-contract MainnetControllerTakeFromSparkVaultE2ETests is MainnetControllerTakeFromSparkVaultTestBase {
+contract MainnetControllerTakeFromSparkVaultE2ETests is ForkTestBase {
 
-    function test_takeFromSparkVault_e2e() external {
-        deal(address(usdc), address(user), 10_000_000e18);
-        vm.startPrank(user);
-        usdc.approve(address(sparkVault), 10_000_000e18);
-        sparkVault.deposit(10_000_000e18, address(user));
+    struct E2ETestState {
+        uint256 takeRateLimit;
+        uint256 transferRateLimit;
+        uint256 daiAlm;
+        uint256 usdcAlm;
+        uint256 usdcVault;
+        uint256 vaultAssetsOut;
+        uint256 vaultTotalAssets;
+        uint256 vaultTotalSupply;
+    }
+
+    address constant ATOKEN_USDS = 0xC02aB1A5eaA8d1B114EF786D9bde108cD4364359;
+
+    address morphoDaiVault = Ethereum.MORPHO_VAULT_DAI_1;
+
+    bytes32 LIMIT_4626_DEPOSIT     = keccak256("LIMIT_4626_DEPOSIT");
+    bytes32 LIMIT_4626_WITHDRAW    = keccak256("LIMIT_4626_WITHDRAW");
+    bytes32 LIMIT_ASSET_TRANSFER   = keccak256("LIMIT_ASSET_TRANSFER");
+    bytes32 LIMIT_SPARK_VAULT_TAKE = keccak256("LIMIT_SPARK_VAULT_TAKE");
+    bytes32 LIMIT_USDS_TO_USDC     = keccak256("LIMIT_USDS_TO_USDC");
+
+    address user = makeAddr("user");
+
+    bytes32 takeKey;
+    bytes32 transferKey;
+
+    SparkVault sparkVault;
+
+    function setUp() public override {
+        super.setUp();
+
+        // Step 1: Deploy the spark vault
+
+        sparkVault = SparkVault(
+            address(new ERC1967Proxy(
+                address(new SparkVault()),
+                abi.encodeCall(
+                    SparkVault.initialize,
+                    (address(usdc), "Spark Savings USDC V2", "spUSDC", Ethereum.SPARK_PROXY)
+                )
+            ))
+        );
+
+        // Step 2 (spell): Grant roles to the almProxy and setter, set VSR bounds
+
+        vm.startPrank(Ethereum.SPARK_PROXY);
+
+        sparkVault.grantRole(sparkVault.TAKER_ROLE(),  address(almProxy));
+        sparkVault.grantRole(sparkVault.SETTER_ROLE(), relayer);
+
+        sparkVault.setVsrBounds(1e27, 1.000000003022265980097387650e27);  // 0% to 10% APY
+
+        // Step 3 (spell): Set the rate limits
+
+        takeKey = RateLimitHelpers.makeAssetKey(
+            LIMIT_SPARK_VAULT_TAKE,
+            address(sparkVault)
+        );
+
+        transferKey = RateLimitHelpers.makeAssetDestinationKey(
+            LIMIT_ASSET_TRANSFER,
+            address(usdc),
+            address(sparkVault)
+        );
+
+        bytes32 morphoKey = RateLimitHelpers.makeAssetKey(
+            LIMIT_4626_DEPOSIT,
+            address(morphoDaiVault)
+        );
+
+        bytes32 morphoWithdrawKey = RateLimitHelpers.makeAssetKey(
+            LIMIT_4626_WITHDRAW,
+            address(morphoDaiVault)
+        );
+
+        rateLimits.setRateLimitData(takeKey,            10_000_000e6,  uint256(10_000_000e6) / 1 days);
+        rateLimits.setRateLimitData(transferKey,        10_000_000e6,  uint256(10_000_000e6) / 1 days);
+        rateLimits.setRateLimitData(morphoKey,          10_000_000e18, uint256(10_000_000e18) / 1 days);
+        rateLimits.setRateLimitData(LIMIT_USDS_TO_USDC, 10_000_000e6, uint256(10_000_000e6) / 1 days);
+
+        rateLimits.setUnlimitedRateLimitData(morphoWithdrawKey);
+
         vm.stopPrank();
+    }
+
+    function _getBlock() internal pure override returns (uint256) {
+        return 23226130;  // August 22, 2025
+    }
+
+    function _assertE2EState(E2ETestState memory state, uint256 tolerance) internal view {
+        assertApproxEqAbs(rateLimits.getCurrentRateLimit(takeKey),     state.takeRateLimit,     tolerance, "takeRateLimit");
+        assertApproxEqAbs(rateLimits.getCurrentRateLimit(transferKey), state.transferRateLimit, tolerance, "transferRateLimit");
+
+        assertApproxEqAbs(dai.balanceOf(address(almProxy)),    state.daiAlm,           tolerance, "daiAlm");
+        assertApproxEqAbs(usdc.balanceOf(address(almProxy)),   state.usdcAlm,          tolerance, "usdcAlm");
+        assertApproxEqAbs(usdc.balanceOf(address(sparkVault)), state.usdcVault,        tolerance, "usdcVault");
+        assertApproxEqAbs(sparkVault.totalAssets(),            state.vaultTotalAssets, tolerance, "vaultTotalAssets");
+        assertApproxEqAbs(sparkVault.totalSupply(),            state.vaultTotalSupply, tolerance, "vaultTotalSupply");
+        assertApproxEqAbs(sparkVault.assetsOutstanding(),      state.vaultAssetsOut,   tolerance, "vaultAssetsOut");
+    }
+
+    function _assertE2EState(E2ETestState memory state) internal view {
+        _assertE2EState(state, 0);
+    }
+
+    function test_e2e_takeFromSparkVault() external {
+        // Step 1: Set the initial state
+
+        E2ETestState memory testState = E2ETestState({
+            takeRateLimit:     10_000_000e6,
+            transferRateLimit: 10_000_000e6,
+            daiAlm:            0,
+            usdcAlm:           0,
+            usdcVault:         0,
+            vaultAssetsOut:    0,
+            vaultTotalAssets:  0,
+            vaultTotalSupply:  0
+        });
+
+        _assertE2EState(testState);
+
+        skip(1 days);
+
+        // Step 2: Deposit usdc into the spark vault
+
+        deal(address(usdc), address(user), 10_000_000e6);
+        vm.startPrank(user);
+        usdc.approve(address(sparkVault), 10_000_000e6);
+        sparkVault.deposit(10_000_000e6, address(user));
+        vm.stopPrank();
+
+        testState.usdcVault        = 10_000_000e6;
+        testState.vaultTotalAssets = 10_000_000e6;
+        testState.vaultTotalSupply = 10_000_000e6;
+
+        _assertE2EState(testState);
+
+        skip(1 days);
+
+        // Step 3: Take usdc from the spark vault
+
+        vm.prank(relayer);
+        mainnetController.takeFromSparkVault(address(sparkVault), 9_000_000e6);
+
+        testState.takeRateLimit  = 1_000_000e6;
+        testState.usdcAlm        = 9_000_000e6;
+        testState.usdcVault      = 1_000_000e6;
+        testState.vaultAssetsOut = 9_000_000e6;
+
+        _assertE2EState(testState);
+
+        skip(10 days);  // Get full rate limit for Morpho deposit
+
+        // Step 4: Swap into DAI, deposit into Morpho, and set the VSR to 4% APY
+
+        vm.startPrank(relayer);
+        mainnetController.swapUSDCToUSDS(9_000_000e6);
+        mainnetController.swapUSDSToDAI(9_000_000e18);
+        uint256 shares = mainnetController.depositERC4626(Ethereum.MORPHO_VAULT_DAI_1, 9_000_000e18);
+        sparkVault.setVsr(1.000000001243680656318820312e27);  // 4% APY
+        vm.stopPrank();
+
+        testState.takeRateLimit = 10_000_000e6;
+        testState.usdcAlm       = 0;
+
+        _assertE2EState(testState);  // No state changes
+
+        skip(365 days);
+
+        // Step 5: Show state change after a year (easiest for APY assertions)
+
+        // 4% APY on 10m USDC = 500k USDC
+        // NOTE: The APY is on the full value of the vault, NOT the take amount.
+        testState.vaultTotalAssets = 10_400_000e6 - 1;  // Rounding
+        testState.vaultAssetsOut   = 9_400_000e6 - 1;   // Rounding
+
+        _assertE2EState(testState);
+
+        // Step 6: Redeem assets from Morpho, swap DAI to USDC and transfer outstanding assets to the vault
+
+        vm.startPrank(relayer);
+        uint256 assets = mainnetController.redeemERC4626(Ethereum.MORPHO_VAULT_DAI_1, shares);
+        mainnetController.swapDAIToUSDS(9_400_000e18);
+        mainnetController.swapUSDSToUSDC(9_400_000e6);
+        mainnetController.transferAsset(address(usdc), address(sparkVault), 9_400_000e6);
+        vm.stopPrank();
+
+        assertEq(assets, 9_414_173.844477081922732043e18);  // ~414k in yield
+
+        uint256 almProfit = assets - 9_400_000e18;  // 9.4m owed to the vault
+
+        testState.transferRateLimit = 600_000e6;  // 10m - 9.4m
+        testState.daiAlm            = almProfit;
+        testState.usdcAlm           = 0;
+        testState.usdcVault         = 10_400_000e6;
+        testState.vaultAssetsOut    = 0;
+
+        _assertE2EState(testState);
+
+        // Step 7: User withdraws all assets
+
+        vm.startPrank(user);
+        sparkVault.withdraw(sparkVault.assetsOf(user), user, user);
+        vm.stopPrank();
+
+        // Vault is empty and ALM system has some profit
+        _assertE2EState(E2ETestState({
+            takeRateLimit:     10_000_000e6,
+            transferRateLimit: 600_000e6,
+            daiAlm:            14_173.844477081922732043e18,  // Profit
+            usdcAlm:           0,
+            usdcVault:         1,  // Rounding against user
+            vaultAssetsOut:    0,
+            vaultTotalAssets:  0,
+            vaultTotalSupply:  0
+        }));
+
+        // User has all funds, and has earned a 4% APY on their deposit
+        assertEq(usdc.balanceOf(user), 10_400_000e6 - 1);  // Rounding against user
     }
 
 }

--- a/test/mainnet-fork/SparkVault.t.sol
+++ b/test/mainnet-fork/SparkVault.t.sol
@@ -135,7 +135,7 @@ contract MainnetControllerTakeFromSparkVaultTests is MainnetControllerTakeFromSp
 
         // 1/24th of the rate limit per hour
         uint256 rateLimitIncreaseInOneHour = uint256(1_000_000e6) / (1 days) * (1 hours);
-        assertEq(rateLimitIncreaseInOneHour, 41666.666666666666666400e18);
+        assertEq(rateLimitIncreaseInOneHour, 41666.666666e6);
 
         testState.rateLimit += rateLimitIncreaseInOneHour;
 


### PR DESCRIPTION
Need to get this in the v1.7 release because the L2 Spark Vault implementations won't work without this addition.

The ForeignController needs to be able to `transferAsset` back into the `vault` for the funds to fully round trip. This was exposed in the e2e tests that were added.